### PR TITLE
Multi-select pre-population

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -46,3 +46,6 @@ input[type="text"].ng-invalid, input[type="email"].ng-invalid, .ui-select-bootst
 }
 
 .angular-google-map-container { height: 300px; }
+
+.map-marker-info-title { font-weight: bold; }
+.map-marker-info-details { font-size: 0.75em; }

--- a/app/app.css
+++ b/app/app.css
@@ -44,3 +44,5 @@ input[type="text"].ng-invalid, input[type="email"].ng-invalid, .ui-select-bootst
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(249, 124, 119, .6);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(249, 124, 119, .6);
 }
+
+.angular-google-map-container { height: 300px; }

--- a/app/app.js
+++ b/app/app.js
@@ -9,6 +9,7 @@ angular.module('csp', [
     'ui.select',
     'ngSanitize',
     'ui.grid',
+    'uiGmapgoogle-maps',
 
     //Services
     'csp.services.parse',
@@ -95,6 +96,14 @@ angular.module('csp', [
         Parse.initialize("WqDGRd0E9ntpvRiU0OlDRYrEr19GflSzWrSzh5kZ", "hqQLu9cUbwFeIPcunmNnBK9VGKD10plbNFMaAgcp");
 
     }]).
+
+    config(function(uiGmapGoogleMapApiProvider) {
+        uiGmapGoogleMapApiProvider.configure({
+            key: 'AIzaSyDjg_uIdwLYCydZY9jbZTnBu0OlpH-3EnQ',
+            v: '3.18',
+            libraries: ''
+        });
+    }).
 
     controller('menuCtrl', ['$scope', '$location', '$window', function ($scope, $location, $window) {
 

--- a/app/appointments/appt-ctrl.js
+++ b/app/appointments/appt-ctrl.js
@@ -1,4 +1,6 @@
-angular.module('csp.appt.ctrl', [])
+angular.module('csp.appt.ctrl', [
+    'uiGmapgoogle-maps'
+])
 
     .controller('apptCtrl', [
         '$scope',
@@ -103,6 +105,14 @@ angular.module('csp.appt.ctrl', [])
             $scope.timePeriods = ['Morning', 'Afternoon', 'Evening'];
 
             $scope.resultRows = locations;
+
+            $scope.map = {
+                center: { latitude: 40.83, longitude: -73.98 },
+                zoom: 12,
+                hasCoordinates: function (location) {
+                    return !!location.coordinates
+                }
+            };
 
             $scope.save = function () {
                 $modal.close($scope.appt);

--- a/app/appointments/appt-ctrl.js
+++ b/app/appointments/appt-ctrl.js
@@ -93,7 +93,9 @@ angular.module('csp.appt.ctrl', [
         'specialties',
         'insCarriers',
         'locations',
-        function ($scope, $modal, $log, $filter, appt, patients, doctors, specialties, insCarriers, locations) {
+        '$timeout',
+        function ($scope, $modal, $log, $filter, appt, patients, doctors, specialties, insCarriers, locations,
+                  $timeout) {
 
             //header text
             $scope.headerText = appt.isNew() ? 'New Appointment' : 'Edit Appointment';
@@ -121,6 +123,7 @@ angular.module('csp.appt.ctrl', [
                                 title: location.doctorfirstName + ' ' + location.doctorlastName,
                                 details: _.map(location.doctorspecialties, 'name').join(', '),
                                 id: location.id,
+                                showWindow: false,
                                 windowOptions: {  // cant' put this into html as anlgular-google-map doesn't support it
                                     disableAutoPan: true,
                                     maxWidth: 100
@@ -143,6 +146,8 @@ angular.module('csp.appt.ctrl', [
 
             $scope.$watch('searchParams', function() {
                 $scope.map.markers = $scope.map.getMarkers();
+                $scope.map.redrawMarkers = true; //workaround for marker windows not showing after filtering
+                $timeout(function() {$scope.map.redrawMarkers = false});
             }, true);
 
             $scope.save = function () {

--- a/app/appointments/appt-ctrl.js
+++ b/app/appointments/appt-ctrl.js
@@ -114,6 +114,10 @@ angular.module('csp.appt.ctrl', [
                 }
             };
 
+            $scope.getSpecialties = function(location) {
+                return _.map(location.doctorspecialties, 'name').join();
+            };
+
             $scope.save = function () {
                 $modal.close($scope.appt);
             };

--- a/app/appointments/appt-ctrl.js
+++ b/app/appointments/appt-ctrl.js
@@ -107,16 +107,43 @@ angular.module('csp.appt.ctrl', [
             $scope.resultRows = locations;
 
             $scope.map = {
-                center: { latitude: 40.83, longitude: -73.98 },
-                zoom: 12,
-                hasCoordinates: function (location) {
-                    return !!location.coordinates
+                center: { //New York
+                    latitude: 40.7055608,
+                    longitude: -74.0283031
+                },
+                zoom: 10,
+                getMarkers: function () {
+                    return _.chain($filter('filter')(locations, $scope.searchParams))
+                        .filter('coordinates')
+                        .map(function (location) {
+                            return {
+                                coordinates: location.coordinates,
+                                title: location.doctorfirstName + ' ' + location.doctorlastName,
+                                details: _.map(location.doctorspecialties, 'name').join(', '),
+                                id: location.id,
+                                windowOptions: {  // cant' put this into html as anlgular-google-map doesn't support it
+                                    disableAutoPan: true,
+                                    maxWidth: 100
+                                }
+                            }
+                        })
+                        .valueOf();
+                },
+                events: {
+                    mouseover: function (gMarker, eventName, model) {
+                        model.showWindow = true;
+                        $scope.$apply();
+                    },
+                    mouseout: function (gMarker, eventName, model) {
+                        model.showWindow = false;
+                        $scope.$apply();
+                    }
                 }
             };
 
-            $scope.getSpecialties = function(location) {
-                return _.map(location.doctorspecialties, 'name').join();
-            };
+            $scope.$watch('searchParams', function() {
+                $scope.map.markers = $scope.map.getMarkers();
+            }, true);
 
             $scope.save = function () {
                 $modal.close($scope.appt);
@@ -142,8 +169,6 @@ angular.module('csp.appt.ctrl', [
                 'phone',
                 {type: 'list', fieldName: 'officeHoursListUnBoxed'}
             ];
-
-            console.log($scope.resultRows);
 
             $scope.searchParams = {
                 'doctorisSpecialist': true

--- a/app/appointments/appt-edit.html
+++ b/app/appointments/appt-edit.html
@@ -117,14 +117,25 @@
     </div>
     <!--Appt Details-->
     <!--<pre>Search Params: {{searchParams}}</pre>-->
-
-    <!--{{resultRows}}-->
-    <pcs-list
-            $log = $log
-            headings="resultHeadings"
-            filter-expression="searchParams"
-            fields="resultFields"
-            rows="resultRows"></pcs-list>
+    <div class="row">
+        <!--{{resultRows}}-->
+        <div class="col-md-8">
+            <pcs-list
+                    $log=$log
+                    headings="resultHeadings"
+                    filter-expression="searchParams"
+                    fields="resultFields"
+                    rows="resultRows"></pcs-list>
+        </div>
+        <div class="col-md-4">
+            <ui-gmap-google-map center='map.center' zoom='map.zoom' ng-if="true">
+                <ui-gmap-marker ng-repeat="location in resultRows | filter:searchParams | filter:map.hasLocation"
+                                coords="location.coordinates"
+                                idkey="location.id">
+                </ui-gmap-marker>
+            </ui-gmap-google-map>
+        </div>
+    </div>
 
     <legend>Appointment Details</legend>
     <form name="mainForm" class="form-horizontal">

--- a/app/appointments/appt-edit.html
+++ b/app/appointments/appt-edit.html
@@ -129,13 +129,15 @@
         </div>
         <div class="col-md-4">
             <ui-gmap-google-map center="map.center" zoom="map.zoom" pan="true">
-                <ui-gmap-markers
+                <ui-gmap-markers ng-if="!map.redrawMarkers"
                         models="map.markers"
                         coords="'coordinates'"
                         events="map.events"
                         fit="true">
-                    <ui-gmap-windows show="'showWindow'" options="'windowOptions'">
-                        <div class="map-marker-info">
+                    <ui-gmap-windows
+                            show="'showWindow'"
+                            options="'windowOptions'">
+                        <div class="map-marker-info" ng-non-bindable>
                             <div class="map-marker-info-title" ng-non-bindable>{{title}}</div>
                             <div class="map-marker-info-details" ng-non-bindable>{{details}}</div>
                         </div>

--- a/app/appointments/appt-edit.html
+++ b/app/appointments/appt-edit.html
@@ -128,17 +128,19 @@
                     rows="resultRows"></pcs-list>
         </div>
         <div class="col-md-4">
-            <ui-gmap-google-map center='map.center' zoom='map.zoom' ng-if="true">
-                <ui-gmap-marker ng-repeat="location in resultRows | filter:searchParams | filter:map.hasLocation"
-                                coords="location.coordinates"
-                                idkey="location.id">
-                    <ui-gmap-window>
+            <ui-gmap-google-map center="map.center" zoom="map.zoom" pan="true">
+                <ui-gmap-markers
+                        models="map.markers"
+                        coords="'coordinates'"
+                        events="map.events"
+                        fit="true">
+                    <ui-gmap-windows show="'showWindow'" options="'windowOptions'">
                         <div class="map-marker-info">
-                            <div class="map-marker-info-title">{{location.doctorfirstName}}&nbsp;{{location.doctorlastName}}</div>
-                            <div class="map-marker-info-details">{{getSpecialties(location)}}</div>
+                            <div class="map-marker-info-title" ng-non-bindable>{{title}}</div>
+                            <div class="map-marker-info-details" ng-non-bindable>{{details}}</div>
                         </div>
-                    </ui-gmap-window>
-                </ui-gmap-marker>
+                    </ui-gmap-windows>
+                </ui-gmap-markers>
             </ui-gmap-google-map>
         </div>
     </div>

--- a/app/appointments/appt-edit.html
+++ b/app/appointments/appt-edit.html
@@ -132,6 +132,12 @@
                 <ui-gmap-marker ng-repeat="location in resultRows | filter:searchParams | filter:map.hasLocation"
                                 coords="location.coordinates"
                                 idkey="location.id">
+                    <ui-gmap-window>
+                        <div class="map-marker-info">
+                            <div class="map-marker-info-title">{{location.doctorfirstName}}&nbsp;{{location.doctorlastName}}</div>
+                            <div class="map-marker-info-details">{{getSpecialties(location)}}</div>
+                        </div>
+                    </ui-gmap-window>
                 </ui-gmap-marker>
             </ui-gmap-google-map>
         </div>

--- a/app/doctors/doctor-edit-ctrl-test.js
+++ b/app/doctors/doctor-edit-ctrl-test.js
@@ -1,20 +1,67 @@
-//describe('doctorEditCtrl test', function() {
-//    beforeEach(module('csp.doctor.ctrl'));
-//
-//    var $controller;
-//
-//    beforeEach(inject(function(_$controller_){
-//        // The injector unwraps the underscores (_) from around the parameter names when matching
-//        $controller = _$controller_;
-//    }));
-//
-//    describe('$scope.grade', function() {
-//        it('sets the strength to "strong" if the password length is >8 chars', function() {
-//            var $scope = {};
-//            var controller = $controller('PasswordController', { $scope: $scope });
-//            $scope.password = 'longerthaneightchars';
-//            $scope.grade();
-//            expect($scope.strength).toEqual('strong');
-//        });
-//    });
-//});
+'use strict';
+
+describe('Doctor Edit Controller', function () {
+
+    beforeEach(module('csp'));
+
+    var $controller,
+        $scope,
+        doctor = {
+            specialties: [],
+            insCarriers: [],
+            salesPeople: [],
+            isNew: function () { return true; }
+        },
+        specialties = [],
+        insCarriers = [],
+        salesPeople = [];
+
+    beforeEach(inject(function (_$controller_) {
+        $controller = _$controller_;
+        $scope = {};
+    }));
+
+    it('should include already selected specialties into the list of all specialties', function () {
+        doctor.specialties.push({id: 1});
+        specialties.push({id: 1});
+        specialties.push({id: 2});
+
+        DoctorEditController();
+
+        expect($scope.specialties[0]).toBe(doctor.specialties[0]);
+    });
+
+    it('should include already selected insurance carriers into the list of all carriers', function () {
+        doctor.insCarriers.push({id: 1});
+        insCarriers.push({id: 1});
+        insCarriers.push({id: 2});
+
+        DoctorEditController();
+
+        expect($scope.insCarriers[0]).toBe(doctor.insCarriers[0]);
+    });
+
+    it('should include already selected sales people into the list of all sales people', function () {
+        doctor.salesPeople.push({id: 1});
+        salesPeople.push({id: 1});
+        salesPeople.push({id: 2});
+
+        DoctorEditController();
+
+        expect($scope.salesPeople[0]).toBe(doctor.salesPeople[0]);
+    });
+
+    function DoctorEditController() {
+        $controller('doctorEditCtrl', {
+            $scope: $scope,
+            $modalInstance: {
+                close: function () {},
+                dismiss: function() {}
+            },
+            doctor: doctor,
+            specialties: specialties,
+            insCarriers: insCarriers,
+            salesPeople: salesPeople
+        });
+    }
+});

--- a/app/doctors/doctor-edit-ctrl.js
+++ b/app/doctors/doctor-edit-ctrl.js
@@ -1,4 +1,9 @@
-angular.module('csp.doctor.ctrl')
+angular.module('csp.doctor.ctrl', [
+    "csp.directive.listHeaderDirective",
+    "csp.directive.listDirective",
+    "csp.services.location",
+    "csp.services.officeHours",
+    "csp.services.parse"])
 
     .controller(
         'doctorEditCtrl',
@@ -13,7 +18,9 @@ angular.module('csp.doctor.ctrl')
             'salesPeople',
             'LocationService',
             'OfficeHoursService',
-            function ($scope, $log, $filter, $modalInstance, doctor, specialties, insCarriers, salesPeople, Location, OfficeHours) {
+            'parseService',
+            function ($scope, $log, $filter, $modalInstance, doctor, specialties, insCarriers, salesPeople, Location,
+                      OfficeHours, parse) {
 
                 $scope.headerText = (doctor.isNew() ? 'New ' : 'Edit ') +
                     (doctor.isReferring ? "Referring Doctor" : "Specialist");
@@ -28,11 +35,11 @@ angular.module('csp.doctor.ctrl')
 
                 $scope.docSpec = angular.copy($scope.doctor.specialties);
 
-                $scope.specialties = specialties;
+                $scope.specialties = parse.replaceSameEntities(specialties, doctor.specialties);
 
-                $scope.insCarriers = insCarriers;
+                $scope.insCarriers = parse.replaceSameEntities(insCarriers, doctor.insCarriers);
 
-                $scope.salesPeople = salesPeople;
+                $scope.salesPeople = parse.replaceSameEntities(salesPeople, doctor.salesPeople);
 
                 $scope.location = new Location();
 

--- a/app/doctors/doctor-edit-ctrl.js
+++ b/app/doctors/doctor-edit-ctrl.js
@@ -3,7 +3,8 @@ angular.module('csp.doctor.ctrl', [
     "csp.directive.listDirective",
     "csp.services.location",
     "csp.services.officeHours",
-    "csp.services.parse"])
+    "csp.services.parse",
+    "csp.services.geocoding"])
 
     .controller(
         'doctorEditCtrl',
@@ -19,8 +20,9 @@ angular.module('csp.doctor.ctrl', [
             'LocationService',
             'OfficeHoursService',
             'parseService',
+            'geocode',
             function ($scope, $log, $filter, $modalInstance, doctor, specialties, insCarriers, salesPeople, Location,
-                      OfficeHours, parse) {
+                      OfficeHours, parse, geocode) {
 
                 $scope.headerText = (doctor.isNew() ? 'New ' : 'Edit ') +
                     (doctor.isReferring ? "Referring Doctor" : "Specialist");
@@ -52,8 +54,14 @@ angular.module('csp.doctor.ctrl', [
                 };
 
                 $scope.addLocation = function () {
-                    doctor.addLocation($scope.location);
-                    $scope.location = new Location();
+                    geocode($scope.location)
+                        .then(function (coordintes) {
+                            $scope.location.coordinates = coordintes;
+                        })
+                        .finally(function () {
+                            doctor.addLocation($scope.location);
+                            $scope.location = new Location();
+                        });
                 };
 
                 $scope.deleteLocation = function (location) {

--- a/app/doctors/doctor-edit.html
+++ b/app/doctors/doctor-edit.html
@@ -185,7 +185,7 @@
             <fieldset style="margin-bottom:10px" ng-if="doctor.isSpecialist">
                 <legend>Specialties</legend>
                 <div class="col-sm-4">
-                    <ui-select multiple ng-model="doctor.specialties" ng-disabled="disabled"
+                    <ui-select multiple ng-model="doctor.specialties"
                                ui-validate="'validateSpecialties($doctor.specialties)'">
                         <ui-select-match placeholder="Specialties...">{{$item.name}}</ui-select-match>
                         <ui-select-choices
@@ -218,8 +218,8 @@
                 <legend>Sales Person(s)</legend>
                 <div class="col-sm-4">
 
-                    <ui-select ng-model="doctor.salesPerson" ng-disabled="disabled">
-                        <ui-select-match placeholder="Sales person...">{{$item.fullName}}
+                    <ui-select multiple ng-model="doctor.salesPeople">
+                        <ui-select-match placeholder="Sales people...">{{$item.fullName}}
                         </ui-select-match>
                         <ui-select-choices repeat="person in salesPeople | filter:$select.search | orderBy: 'name'">
                             <div ng-bind-html="name.name.htmlSafe | highlight: $select.search"></div>

--- a/app/doctors/doctor-list-ctrl.js
+++ b/app/doctors/doctor-list-ctrl.js
@@ -1,8 +1,4 @@
-angular.module('csp.doctor.ctrl', [
-    "csp.directive.listHeaderDirective",
-    "csp.directive.listDirective",
-    "csp.services.location",
-    "csp.services.officeHours"])
+angular.module('csp.doctor.ctrl')
     .controller(
         'doctorListCtrl',
         [

--- a/app/doctors/doctor-service.js
+++ b/app/doctors/doctor-service.js
@@ -54,6 +54,8 @@ angular.module('csp.services.doctor', [
                         "company",
                         "active",
                         "specialties",
+                        "insCarriers",
+                        "salesPeople",
                         "locations",
                         "note",
                         "type"
@@ -88,26 +90,15 @@ angular.module('csp.services.doctor', [
         'DoctorService',
         'SpecialtyService',
         'InsCarrierService',
+        'SalesPersonService',
         'LocationService',
-        '$q',
-        function (Doctor, Specialty, InsCarrier, Location,$q) {
-            var defer = $q.defer();
+        function (Doctor) {
             var query = new Parse.Query(Doctor);
 
             query.include('specialties');
             query.include('insCarriers');
+            query.include('salesPeople');
             query.include('locations');
 
-            query.find({
-                success : function(aPresentations) {
-                    defer.resolve(aPresentations);
-                },
-                error : function(aError) {
-                    defer.reject(aError);
-                }
-            });
-
-            return defer.promise;
-
-            //return query.find();
+            return query.find();
         }]);

--- a/app/index.html
+++ b/app/index.html
@@ -46,7 +46,7 @@
 
   <script src="bower_components/angular-ui-grid/ui-grid.min.js"></script>
 
-  <script src="bower_components/angular-google-maps/dist/angular-google-maps.min.js"></script>
+  <script src="bower_components/angular-google-maps/dist/angular-google-maps.js"></script>
 
   <script src="bower_components/parse/parse.min.js"></script>
   <script src="bower_components/moment/moment.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -81,8 +81,8 @@
 
   <!--controllers-->
   <script src="patients/patient-ctrl.js"></script>
-  <script src="doctors/doctor-list-ctrl.js"></script>
   <script src="doctors/doctor-edit-ctrl.js"></script>
+  <script src="doctors/doctor-list-ctrl.js"></script>
   <script src="appointments/appt-ctrl.js"></script>
   <script src="shared/ctrls/named-ctrl.js"></script>
 

--- a/app/index.html
+++ b/app/index.html
@@ -36,6 +36,8 @@
   <script src="bower_components/angular-ui-utils/ui-utils.min.js"></script>
   <script src="bower_components/angular-route/angular-route.js"></script>
 
+  <script src="bower_components/lodash/dist/lodash.min.js"></script>
+
   <!--uiselect stuff-->
   <script src="bower_components/angular-bootstrap/ui-bootstrap.js"></script>
   <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
@@ -44,11 +46,9 @@
 
   <script src="bower_components/angular-ui-grid/ui-grid.min.js"></script>
 
-
+  <script src="bower_components/angular-google-maps/dist/angular-google-maps.min.js"></script>
 
   <script src="bower_components/parse/parse.min.js"></script>
-  <script src="bower_components/lodash/dist/lodash.min.js"></script>
-  <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
   <script src="bower_components/moment/moment.js"></script>
 
   <!--app-->
@@ -73,6 +73,8 @@
   <script src="shared/services/specialty-service.js"></script>
 
   <script src="shared/services/ins-carrier-service.js"></script>
+
+  <script src="shared/services/geocoding-service.js"></script>
 
   <!--directives-->
   <script src="shared/directives/list-directive.js"></script>

--- a/app/locations/location-service.js
+++ b/app/locations/location-service.js
@@ -38,7 +38,8 @@ angular.module('csp.services.location', ['csp.services.doctor']).
                 "zip",
                 "phone",
                 "email",
-                "officeHours"
+                "officeHours",
+                "coordinates"
             ]
         );
 

--- a/app/patients/patient-ctrl-test.js
+++ b/app/patients/patient-ctrl-test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+describe('Patient Edit Controller', function () {
+
+    beforeEach(module('csp'));
+
+    var $controller,
+        $scope,
+        patient = {
+            insCarriers: [],
+            isNew: function () { return true; }
+        },
+        insCarriers = [];
+
+    beforeEach(inject(function (_$controller_) {
+        $controller = _$controller_;
+        $scope = {};
+    }));
+
+    it('should include already selected insurance carriers into the list of all carriers', function () {
+        patient.insCarriers.push({id: 1});
+        insCarriers.push({id: 1});
+        insCarriers.push({id: 2});
+
+        PatientEditController();
+
+        expect($scope.insCarriers[0]).toBe(patient.insCarriers[0]);
+    });
+
+    function PatientEditController() {
+        $controller('patientEditCtrl', {
+            $scope: $scope,
+            $modalInstance: {
+                close: function () {},
+                dismiss: function() {}
+            },
+            patient: patient,
+            insCarriers: insCarriers
+        });
+    }
+});

--- a/app/patients/patient-ctrl.js
+++ b/app/patients/patient-ctrl.js
@@ -1,5 +1,6 @@
 angular.module('csp.patient.ctrl', [
-    'csp.services.parse'
+    'csp.services.parse',
+    'csp.services.geocoding'
 ])
 
     .controller(
@@ -80,7 +81,8 @@ angular.module('csp.patient.ctrl', [
             'patient',
             'insCarriers',
             'parseService',
-            function ($scope, $modalInstance, patient, insCarriers, parse) {
+            'geocode',
+            function ($scope, $modalInstance, patient, insCarriers, parse, geocode) {
 
                 //header text
                 $scope.headerText = patient.isNew() ? 'New Patient' : 'Edit Patient';
@@ -90,7 +92,13 @@ angular.module('csp.patient.ctrl', [
                 $scope.insCarriers = parse.replaceSameEntities(insCarriers, patient.insCarriers);
 
                 $scope.save = function () {
-                    $modalInstance.close($scope.patient);
+                    geocode(patient)
+                        .then(function (coordintes) {
+                            patient.coordinates = coordintes;
+                        })
+                        .finally(function () {
+                            $modalInstance.close($scope.patient);
+                        });
                 };
 
                 $scope.close = function () {

--- a/app/patients/patient-ctrl.js
+++ b/app/patients/patient-ctrl.js
@@ -1,4 +1,6 @@
-angular.module('csp.patient.ctrl', [])
+angular.module('csp.patient.ctrl', [
+    'csp.services.parse'
+])
 
     .controller(
         'patientListCtrl',
@@ -77,14 +79,15 @@ angular.module('csp.patient.ctrl', [])
             '$modalInstance',
             'patient',
             'insCarriers',
-            function ($scope, $modalInstance, patient, insCarriers) {
+            'parseService',
+            function ($scope, $modalInstance, patient, insCarriers, parse) {
 
                 //header text
                 $scope.headerText = patient.isNew() ? 'New Patient' : 'Edit Patient';
 
                 $scope.patient = patient;
 
-                $scope.insCarriers = insCarriers;
+                $scope.insCarriers = parse.replaceSameEntities(insCarriers, patient.insCarriers);
 
                 $scope.save = function () {
                     $modalInstance.close($scope.patient);

--- a/app/patients/patient-service.js
+++ b/app/patients/patient-service.js
@@ -39,5 +39,6 @@ angular.module('csp.services.patient', ['csp.services.insCarrier']).
         'InsCarrierService',
         function (Patient) {
             var query = new Parse.Query(Patient);
+            query.include('insCarriers');
             return query.find();
         }]);

--- a/app/patients/patient-service.js
+++ b/app/patients/patient-service.js
@@ -24,6 +24,7 @@ angular.module('csp.services.patient', ['csp.services.insCarrier']).
                     "zip",
                     "phone",
                     "email",
+                    "coordinates",
                     "active",
                     "dob",
                     "insCarriers",

--- a/app/shared/services/geocoding-service.js
+++ b/app/shared/services/geocoding-service.js
@@ -1,0 +1,30 @@
+'use strict';
+
+angular.module('csp.services.geocoding', [
+    'csp.services.parse'
+])
+    .service('geocode', ['uiGmapGoogleMapApi', '$q', 'parseService', function (uiGmapGoogleMapApi, $q, parse) {
+        return function (location) {
+            var address = [
+                location.address,
+                location.city,
+                location.state,
+                location.zip
+            ].join();
+
+            var deferred = $q.defer();
+
+            uiGmapGoogleMapApi.then(function (maps) {
+                new maps.Geocoder().geocode({address: address}, function (result, status) {
+                    if (status === maps.GeocoderStatus.OK) {
+                        var googleLocation = result[0].geometry.location;
+                        deferred.resolve(parse.geoPoint(googleLocation.lat(), googleLocation.lng()));
+                    } else {
+                        deferred.reject();
+                    }
+                });
+            });
+
+            return deferred.promise;
+        };
+    }]);

--- a/app/shared/services/parse-service-test.js
+++ b/app/shared/services/parse-service-test.js
@@ -104,5 +104,16 @@ describe('Parse Service Test', function () {
             expect(actual[0]).toBe(a2);
             expect(actual[1]).toBe(b);
         }));
+
+        it('should allow undefined instancesToReplaceWith collection', inject(function (parseService) {
+            var a = {id: '1'},
+                b = {id: '2'};
+
+            var actual = parseService.replaceSameEntities([a, b], undefined);
+
+            expect(actual.length).toBe(2);
+            expect(actual[0]).toBe(a);
+            expect(actual[1]).toBe(b);
+        }));
     });
 });

--- a/app/shared/services/parse-service-test.js
+++ b/app/shared/services/parse-service-test.js
@@ -92,4 +92,17 @@ describe('Parse Service Test', function () {
         }));
 
     });
+
+    describe('parse service, replaceSameEntities', function () {
+        it('should replace intance with the same Parse entity id', inject(function (parseService) {
+            var a1 = {id: '1'},
+                b = {id: '2'},
+                a2 = {id: '1'};
+
+            var actual = parseService.replaceSameEntities([a1, b], [a2]);
+
+            expect(actual[0]).toBe(a2);
+            expect(actual[1]).toBe(b);
+        }));
+    });
 });

--- a/app/shared/services/parse-service.js
+++ b/app/shared/services/parse-service.js
@@ -139,6 +139,10 @@ angular.module('csp.services.parse', []).
             return result;
         };
 
+        parseService.geoPoint = function(latitude, longitude) {
+            return new Parse.GeoPoint({latitude: latitude, longitude: longitude});
+        };
+
 
         /**
          * Priavate utility property setters and getters.

--- a/app/shared/services/parse-service.js
+++ b/app/shared/services/parse-service.js
@@ -104,6 +104,40 @@ angular.module('csp.services.parse', []).
             return result;
         };
 
+        /**
+         * Replaces instances of Parse objects in entities collection with instancesToReplaceWith when they match by
+         * Parse object id.
+         * This is required when there are multiple instances of the same Parse entity. This happens when they are
+         * pulled by different Parse queries, e.g. pulling patients with child collections of associated insurance
+         * carriers and the full list of insurance carriers in a separate query. These instances will not be equal while
+         * they represent the same Parse entity. If you bind patient's insurance carriers and the full list of
+         * insurance carriers to say multi select control then it will not behave as expected.
+         *
+         *
+         * @param entities
+         * @param instancesToReplaceWith
+         * @returns {Array}
+         */
+        parseService.replaceSameEntities = function (entities, instancesToReplaceWith) {
+            if (!(angular.isArray(entities) && angular.isArray(instancesToReplaceWith))) {
+                console.log("parseService.replaceSameEntities is used with illegal parameters");
+                return [];
+            }
+
+            var result = [];
+
+            entities.forEach(function (entity) {
+                var instanceToReplaceWith = _.find(instancesToReplaceWith, {'id': entity.id});
+                if (instanceToReplaceWith) {
+                    result.push(instanceToReplaceWith);
+                } else {
+                    result.push(entity);
+                }
+            });
+
+            return result;
+        };
+
 
         /**
          * Priavate utility property setters and getters.

--- a/app/shared/services/parse-service.js
+++ b/app/shared/services/parse-service.js
@@ -119,6 +119,7 @@ angular.module('csp.services.parse', []).
          * @returns {Array}
          */
         parseService.replaceSameEntities = function (entities, instancesToReplaceWith) {
+            instancesToReplaceWith = instancesToReplaceWith || [];
             if (!(angular.isArray(entities) && angular.isArray(instancesToReplaceWith))) {
                 console.log("parseService.replaceSameEntities is used with illegal parameters");
                 return [];

--- a/bower.json
+++ b/bower.json
@@ -13,14 +13,15 @@
     "angular-animate": "1.2.x",
     "angular-sanitize": "1.2.x",
     "angular-touch": "1.2.x",
-    "angular-ui-select" : "latest",
-    "angular-ui-utils" : "latest",
+    "angular-ui-select": "latest",
+    "angular-ui-utils": "latest",
     "html5-boilerplate": "~4.3.0",
     "moment": "~2.8.3",
     "angular-bootstrap": "~0.12.0",
     "angular-ui-grid": "~3.0.0-rc.16",
     "lodash": "~2.4.1",
     "parse": "~1.3.1",
-    "bootstrap": "latest"
+    "bootstrap": "latest",
+    "angular-google-maps": "~2.0.11"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "lodash": "~2.4.1",
     "parse": "~1.3.1",
     "bootstrap": "latest",
-    "angular-google-maps": "~2.0.11"
+    "angular-google-maps": "~2.0.12"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,14 +16,22 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'app/bower_components/angular/angular.js',
-      'app/bower_components/angular-mocks/angular-mocks.js',   // for angular.mock.module and inject.
+      'app/bower_components/angular-route/angular-route.min.js',
+      'app/bower_components/angular-sanitize/angular-sanitize.min.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',   // for angular.mock.module and inject.'
+      'app/bower_components/angular-bootstrap/ui-bootstrap.min.js',
+      'app/bower_components/angular-ui-utils/ui-utils.min.js',
+      'app/bower_components/angular-ui-select/dist/select.min.js',
+      'app/bower_components/angular-ui-grid/ui-grid.min.js',
       'app/bower_components/moment/moment.js',
-      'components/low-dash/lodash.min.js',
-      'components/parse/parse-1.3.1.min.js',
+      'app/bower_components/lodash/dist/lodash.min.js',
+      'app/bower_components/parse/parse.min.js',
       'app/parse-init.js',
+      'app/**/*-ctrl.js',             // application sources
       'app/**/*-service.js',             // application sources
       'app/**/*-directive.js',             // application sources
-      'app/**/*-test.js'
+      'app/**/*-test.js',
+      'app/app.js'
     ],
 
 


### PR DESCRIPTION
- Added loading of child entities, e.g. loadng insCarriers for patients
- Dealt with the issue that patient.insCarriers collection contains different instances of the same InsCarrier entities when compared to the full list of InsCarriers pulled with a different Parse query. This was causing issues with the multi-select UI control
- Added insCarriers and salesPeople properties to Doctor entity
- Changed ui-select for doctor -> sales people to be multi-select
- Changed karma.conf.js to allow referencing the entire csp module in unit tests
- Tested with angular-ui-select v0.9.5
